### PR TITLE
Makes the semicolon white in the VS2013 Dark theme

### DIFF
--- a/VS2013_Dark/VS2013_Dark.StorableColorTheme.ps1xml
+++ b/VS2013_Dark/VS2013_Dark.StorableColorTheme.ps1xml
@@ -807,7 +807,7 @@
       <ScB>0.8713671</ScB>
     </Color>
   </Values>
-  <Name>(Customized Theme)</Name>
+  <Name>VS2013 Dark</Name>
   <FontFamily>Lucida Console</FontFamily>
   <FontSize>10</FontSize>
 </StorableColorTheme>

--- a/VS2013_Dark/VS2013_Dark.StorableColorTheme.ps1xml
+++ b/VS2013_Dark/VS2013_Dark.StorableColorTheme.ps1xml
@@ -358,13 +358,13 @@
     </Color>
     <Color>
       <A>255</A>
-      <R>36</R>
-      <G>36</G>
-      <B>36</B>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
       <ScA>1</ScA>
-      <ScR>0.0176419541</ScR>
-      <ScG>0.0176419541</ScG>
-      <ScB>0.0176419541</ScB>
+      <ScR>1</ScR>
+      <ScG>1</ScG>
+      <ScB>1</ScB>
     </Color>
     <Color>
       <A>255</A>
@@ -807,7 +807,7 @@
       <ScB>0.8713671</ScB>
     </Color>
   </Values>
-  <Name>VS2013 Dark</Name>
+  <Name>(Customized Theme)</Name>
   <FontFamily>Lucida Console</FontFamily>
   <FontSize>10</FontSize>
 </StorableColorTheme>


### PR DESCRIPTION
Currently the semicolon in the VS2013 Dark theme seems to be transparent.

I made it white and saved the theme out.